### PR TITLE
fix migrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
         "sqlite3": "^5.1.7",
-        "typeorm": "^0.3.20"
+        "typeorm": "^0.3.24"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.0",
@@ -3207,11 +3207,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
+    "node_modules/ansis": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
+      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -4027,82 +4029,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cli-highlight": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
-      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "highlight.js": "^10.7.1",
-        "mz": "^2.4.0",
-        "parse5": "^5.1.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.0",
-        "yargs": "^16.0.0"
-      },
-      "bin": {
-        "highlight": "bin/highlight"
-      },
-      "engines": {
-        "node": ">=8.0.0",
-        "npm": ">=5.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
@@ -4460,10 +4386,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4492,11 +4417,9 @@
       }
     },
     "node_modules/dedent": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-      "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-      "dev": true,
-      "license": "MIT",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -4649,10 +4572,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "license": "BSD-2-Clause",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
       "engines": {
         "node": ">=12"
       },
@@ -5847,6 +5769,7 @@
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
       "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -6007,15 +5930,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/html-escaper": {
@@ -8043,17 +7957,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -8484,27 +8387,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/parse5": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
-      "license": "MIT"
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-      "license": "MIT",
-      "dependencies": {
-        "parse5": "^6.0.1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -9810,6 +9692,21 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/sql-highlight": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/sql-highlight/-/sql-highlight-6.0.0.tgz",
+      "integrity": "sha512-+fLpbAbWkQ+d0JEchJT/NrRRXbYRNbG15gFpANx73EwxQB1PRjj+k/OI0GTU0J63g8ikGkJECQp9z8XEJZvPRw==",
+      "funding": [
+        "https://github.com/scriptcoded/sql-highlight?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/scriptcoded"
+        }
+      ],
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/sqlite3": {
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
@@ -10391,27 +10288,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -10728,26 +10604,24 @@
       "license": "MIT"
     },
     "node_modules/typeorm": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.20.tgz",
-      "integrity": "sha512-sJ0T08dV5eoZroaq9uPKBoNcGslHBR4E4y+EBHs//SiGbblGe7IeduP/IH4ddCcj0qp3PHwDwGnuvqEAnKlq/Q==",
-      "license": "MIT",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.24.tgz",
+      "integrity": "sha512-4IrHG7A0tY8l5gEGXfW56VOMfUVWEkWlH/h5wmcyZ+V8oCiLj7iTPp0lEjMEZVrxEkGSdP9ErgTKHKXQApl/oA==",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
+        "ansis": "^3.17.0",
         "app-root-path": "^3.1.0",
         "buffer": "^6.0.3",
-        "chalk": "^4.1.2",
-        "cli-highlight": "^2.1.11",
-        "dayjs": "^1.11.9",
-        "debug": "^4.3.4",
-        "dotenv": "^16.0.3",
-        "glob": "^10.3.10",
-        "mkdirp": "^2.1.3",
-        "reflect-metadata": "^0.2.1",
+        "dayjs": "^1.11.13",
+        "debug": "^4.4.0",
+        "dedent": "^1.6.0",
+        "dotenv": "^16.4.7",
+        "glob": "^10.4.5",
         "sha.js": "^2.4.11",
-        "tslib": "^2.5.0",
-        "uuid": "^9.0.0",
-        "yargs": "^17.6.2"
+        "sql-highlight": "^6.0.0",
+        "tslib": "^2.8.1",
+        "uuid": "^11.1.0",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "typeorm": "cli.js",
@@ -10761,23 +10635,24 @@
         "url": "https://opencollective.com/typeorm"
       },
       "peerDependencies": {
-        "@google-cloud/spanner": "^5.18.0",
+        "@google-cloud/spanner": "^5.18.0 || ^6.0.0 || ^7.0.0",
         "@sap/hana-client": "^2.12.25",
-        "better-sqlite3": "^7.1.2 || ^8.0.0 || ^9.0.0",
+        "better-sqlite3": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
         "hdb-pool": "^0.1.6",
         "ioredis": "^5.0.4",
-        "mongodb": "^5.8.0",
-        "mssql": "^9.1.1 || ^10.0.1",
+        "mongodb": "^5.8.0 || ^6.0.0",
+        "mssql": "^9.1.1 || ^10.0.1 || ^11.0.1",
         "mysql2": "^2.2.5 || ^3.0.1",
         "oracledb": "^6.3.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
         "redis": "^3.1.1 || ^4.0.0",
+        "reflect-metadata": "^0.1.14 || ^0.2.0",
         "sql.js": "^1.4.0",
         "sqlite3": "^5.0.3",
         "ts-node": "^10.7.0",
-        "typeorm-aurora-data-api-driver": "^2.0.0"
+        "typeorm-aurora-data-api-driver": "^2.0.0 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "@google-cloud/spanner": {
@@ -10867,19 +10742,40 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/typeorm/node_modules/mkdirp": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
-      "integrity": "sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
+    "node_modules/typeorm/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": ">=10"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typeorm/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/typeorm/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "sqlite3": "^5.1.7",
-    "typeorm": "^0.3.20"
+    "typeorm": "^0.3.24"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,7 +20,8 @@ import migrations from '../migrations';
       type: 'sqlite',
       database: 'db',
       entities: [Blog, User, File],
-      migrations: migrations
+      migrations: migrations,
+      migrationsRun: true,
     }),
     UserModule,
     BlogModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,16 +2,16 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { BlogModule } from 'src/blog/blog.module';
-import { Blog } from 'src/blog/entities/blog.entity';
+import { BlogModule } from '../blog/blog.module';
+import { Blog } from '../blog/entities/blog.entity';
 // import { BookModule } from 'src/book/book.module';
 // import { Book } from 'src/book/entities/book.entity';
-import { User } from 'src/user/entities/user.entity';
-import { UserModule } from 'src/user/user.module';
+import { User } from '../user/entities/user.entity';
+import { UserModule } from '../user/user.module';
 // import { ReviewModule } from 'src/review/review.module';
 // import { Review } from 'src/review/entities/review.entity';
-import { File } from 'src/file/entities/file.entity';
-import { FileModule } from 'src/file/file.module';
+import { File } from '../file/entities/file.entity';
+import { FileModule } from '../file/file.module';
 
 @Module({
   imports: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { UserModule } from '../user/user.module';
 // import { Review } from 'src/review/entities/review.entity';
 import { File } from '../file/entities/file.entity';
 import { FileModule } from '../file/file.module';
+import migrations from '../migrations';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { FileModule } from '../file/file.module';
       type: 'sqlite',
       database: 'db',
       entities: [Blog, User, File],
+      migrations: migrations
     }),
     UserModule,
     BlogModule,

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { Blog } from './entities/blog.entity';
 import { UserService } from '../user/user.service';
 import { CreateBlogDto } from './dto/create-blog.dto';
-import { FileService } from 'src/file/file.service';
+import { FileService } from '../file/file.service';
 import { UpdateBlogDto } from './dto/update-blog.dto';
 
 @Injectable()

--- a/src/blog/entities/blog.entity.ts
+++ b/src/blog/entities/blog.entity.ts
@@ -1,6 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, OneToMany } from 'typeorm'
-import { User } from 'src/user/entities/user.entity';
-import { File } from 'src/file/entities/file.entity';
+import { User } from '../../user/entities/user.entity';
+import { File } from '../../file/entities/file.entity';
 
 @Entity()
 export class Blog {

--- a/src/file/entities/file.entity.ts
+++ b/src/file/entities/file.entity.ts
@@ -1,5 +1,5 @@
-import { Blog } from "src/blog/entities/blog.entity";
-import { User } from "src/user/entities/user.entity";
+import { Blog } from "../../blog/entities/blog.entity";
+import { User } from "../../user/entities/user.entity";
 import { Column, Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity()

--- a/src/migrations/1748620719658-Init.ts
+++ b/src/migrations/1748620719658-Init.ts
@@ -4,12 +4,28 @@ export class Init1748620719658 implements MigrationInterface {
     name = 'Init1748620719658'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`CREATE TABLE "file" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "providerKey" varchar NOT NULL, "filename" varchar NOT NULL, "contentType" varchar NOT NULL, "contentSize" integer NOT NULL, "user_id" integer, "blog_id" integer, CONSTRAINT "REL_516f1cf15166fd07b732b4b6ab" UNIQUE ("user_id"))`);
-        await queryRunner.query(`CREATE TABLE "user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "username" varchar NOT NULL, "email" varchar NOT NULL)`);
-        await queryRunner.query(`CREATE TABLE "blog" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "title" varchar NOT NULL, "content" varchar NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "updatedAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "author_id" integer)`);
+        await queryRunner.query(`CREATE TABLE "file" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "providerKey" varchar NOT NULL, "filename" varchar NOT NULL, "contentType" varchar NOT NULL, "contentSize" integer NOT NULL)`);
+        await queryRunner.query(`CREATE TABLE "user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "username" varchar NOT NULL, "email" varchar NOT NULL, "profile_picture_id" integer, CONSTRAINT "REL_e4238c3828bc51ff8ca27c4638" UNIQUE ("profile_picture_id"))`);
+        await queryRunner.query(`CREATE TABLE "blog" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "title" varchar NOT NULL, "content" text NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "updatedAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "cover_image_id" integer, "author_id" integer, CONSTRAINT "REL_413c018fa50b488485364ad9fc" UNIQUE ("cover_image_id"))`);
+        await queryRunner.query(`CREATE TABLE "temporary_user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "username" varchar NOT NULL, "email" varchar NOT NULL, "profile_picture_id" integer, CONSTRAINT "REL_e4238c3828bc51ff8ca27c4638" UNIQUE ("profile_picture_id"), CONSTRAINT "FK_e4238c3828bc51ff8ca27c46385" FOREIGN KEY ("profile_picture_id") REFERENCES "file" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`);
+        await queryRunner.query(`INSERT INTO "temporary_user"("id", "username", "email", "profile_picture_id") SELECT "id", "username", "email", "profile_picture_id" FROM "user"`);
+        await queryRunner.query(`DROP TABLE "user"`);
+        await queryRunner.query(`ALTER TABLE "temporary_user" RENAME TO "user"`);
+        await queryRunner.query(`CREATE TABLE "temporary_blog" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "title" varchar NOT NULL, "content" text NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "updatedAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "cover_image_id" integer, "author_id" integer, CONSTRAINT "REL_413c018fa50b488485364ad9fc" UNIQUE ("cover_image_id"), CONSTRAINT "FK_413c018fa50b488485364ad9fcd" FOREIGN KEY ("cover_image_id") REFERENCES "file" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION, CONSTRAINT "FK_f8ff9a5fe63d10137f01451e0a2" FOREIGN KEY ("author_id") REFERENCES "user" ("id") ON DELETE NO ACTION ON UPDATE NO ACTION)`);
+        await queryRunner.query(`INSERT INTO "temporary_blog"("id", "title", "content", "createdAt", "updatedAt", "cover_image_id", "author_id") SELECT "id", "title", "content", "createdAt", "updatedAt", "cover_image_id", "author_id" FROM "blog"`);
+        await queryRunner.query(`DROP TABLE "blog"`);
+        await queryRunner.query(`ALTER TABLE "temporary_blog" RENAME TO "blog"`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "blog" RENAME TO "temporary_blog"`);
+        await queryRunner.query(`CREATE TABLE "blog" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "title" varchar NOT NULL, "content" text NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "updatedAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "cover_image_id" integer, "author_id" integer, CONSTRAINT "REL_413c018fa50b488485364ad9fc" UNIQUE ("cover_image_id"))`);
+        await queryRunner.query(`INSERT INTO "blog"("id", "title", "content", "createdAt", "updatedAt", "cover_image_id", "author_id") SELECT "id", "title", "content", "createdAt", "updatedAt", "cover_image_id", "author_id" FROM "temporary_blog"`);
+        await queryRunner.query(`DROP TABLE "temporary_blog"`);
+        await queryRunner.query(`ALTER TABLE "user" RENAME TO "temporary_user"`);
+        await queryRunner.query(`CREATE TABLE "user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "username" varchar NOT NULL, "email" varchar NOT NULL, "profile_picture_id" integer, CONSTRAINT "REL_e4238c3828bc51ff8ca27c4638" UNIQUE ("profile_picture_id"))`);
+        await queryRunner.query(`INSERT INTO "user"("id", "username", "email", "profile_picture_id") SELECT "id", "username", "email", "profile_picture_id" FROM "temporary_user"`);
+        await queryRunner.query(`DROP TABLE "temporary_user"`);
         await queryRunner.query(`DROP TABLE "blog"`);
         await queryRunner.query(`DROP TABLE "user"`);
         await queryRunner.query(`DROP TABLE "file"`);

--- a/src/migrations/1748620719658-Init.ts
+++ b/src/migrations/1748620719658-Init.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class Init1748620719658 implements MigrationInterface {
+    name = 'Init1748620719658'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "file" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "providerKey" varchar NOT NULL, "filename" varchar NOT NULL, "contentType" varchar NOT NULL, "contentSize" integer NOT NULL, "user_id" integer, "blog_id" integer, CONSTRAINT "REL_516f1cf15166fd07b732b4b6ab" UNIQUE ("user_id"))`);
+        await queryRunner.query(`CREATE TABLE "user" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "username" varchar NOT NULL, "email" varchar NOT NULL)`);
+        await queryRunner.query(`CREATE TABLE "blog" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "title" varchar NOT NULL, "content" varchar NOT NULL, "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "updatedAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "author_id" integer)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "blog"`);
+        await queryRunner.query(`DROP TABLE "user"`);
+        await queryRunner.query(`DROP TABLE "file"`);
+    }
+
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,0 +1,5 @@
+import { Init1748620719658 } from "./1748620719658-Init";
+
+export default [
+  Init1748620719658
+];

--- a/src/user/dto/user-response.dto.ts
+++ b/src/user/dto/user-response.dto.ts
@@ -1,6 +1,6 @@
 import { IsEmail, IsNumber, IsOptional, IsString } from 'class-validator';
-import { BlogResponseDto } from 'src/blog/dto/blog-response.dto';
-import { FileResponseDto } from 'src/file/dto/file-response.dto';
+import { BlogResponseDto } from '../../blog/dto/blog-response.dto';
+import { FileResponseDto } from '../../file/dto/file-response.dto';
 
 export class UserResponseDto {
   @IsNumber()

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,5 +1,5 @@
-import { Blog } from 'src/blog/entities/blog.entity';
-import { File } from 'src/file/entities/file.entity';
+import { Blog } from '../../blog/entities/blog.entity';
+import { File } from '../../file/entities/file.entity';
 import { Entity, PrimaryGeneratedColumn, Column, OneToOne, JoinColumn, OneToMany } from 'typeorm'
 import { IsEmail } from 'class-validator';
 


### PR DESCRIPTION
## Purpose
Migration generations failed previously:
![image](https://github.com/user-attachments/assets/453af014-846e-4c0b-95fe-bef429d93c63)

This PR merges Devin's fixes on migrations:
* Updated typeorm to the latest version.
* Replaced all imports starting with `src` with relative imports (`./..`). `src` imports will work during development and build, however, the typeorm cli can't resolve them.
* Added migrations to the TypeORM module in `app.module` so that they run on startup.

## Setup
To install the fixes in this PR:
```sh
npm install
rm db
npm run start # this will auto run migrations on startup
```

To auto generate future migrations based on the differences between your current db and TypeORM entities:
```sh
npm run migration:generate src/migrations/<replace_migration_filename>
```